### PR TITLE
Try to catch tiny alignments, output no further subclusters

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -212,6 +212,8 @@ rule bactdating:
         sorted="output/strains/{strain}/sorted.rds"
     group:
         "outbreak"
+    params:
+        script=config["poppipe_location"] + "/scripts/run_bactDating.R"
     log:
         "logs/bactdating_{strain}.log"
     conda:
@@ -219,7 +221,7 @@ rule bactdating:
     threads:
         4
     shell:
-        "Rscript --vanilla scripts/run_bactDating.R output/strains/{wildcards.strain}/gubbins {input.metadata} {output.sorted} {output.rds} > {log}"
+        "Rscript --vanilla {params.script} output/strains/{wildcards.strain}/gubbins {input.metadata} {output.sorted} {output.rds} > {log}"
 
 # dummy target rule
 rule transmission:
@@ -239,6 +241,7 @@ rule transphylo:
     group:
         "outbreak"
     params:
+        script=config["poppipe_location"] + "/scripts/run_transPhylo.R",
         w_shape=config['transphylo']['w_shape'],
         w_scale=config['transphylo']['w_scale'],
         mcmcIterations=config['transphylo']['mcmcIterations'],
@@ -256,14 +259,13 @@ rule transphylo:
     threads:
         4
     shell:
-        "Rscript --vanilla scripts/run_transPhylo.R --rds {input.rds} --sorted {input.sorted} --output {output}\
+        "Rscript --vanilla {params.script} --rds {input.rds} --sorted {input.sorted} --output {output} \
         --gubbins {params.gubbins} --wshape {params.w_shape} \
         --wscale {params.w_scale} --mcmcIterations {params.mcmcIterations} \
         --startNeg {params.startNeg} --startOffr {params.startOff_r} \
         --startOffp {params.startOff_p} --startPi {params.startPi} \
         --optiStart {params.optiStart} --dateT {params.dateT} > {log}"
 
-# in tree + aln mode
 rule fastbaps:
     input:
         tree="output/strains/{strain}/besttree.nwk",
@@ -273,7 +275,7 @@ rule fastbaps:
     group:
         "bapsclust"
     params:
-        fb_script=config['fastbaps']['script'],
+        script=config["poppipe_location"] + "/scripts/run_fastbaps.R",
         levels=config['fastbaps']['levels']
     log:
         "logs/fastbaps_{strain}.log"
@@ -282,7 +284,7 @@ rule fastbaps:
     threads:
         4
     shell:
-        "{params.fb_script} -p 'baps' -i {input.align} -o {output} -l {params.levels} --phylogeny={input.tree} -t {threads} > {log}"
+        "Rscript --vanilla {params.script} {input.align} {output} {params.levels} {input.tree} {threads} > {log}"
 
 # Visualisation below here:
 rule graft_tree:

--- a/config.schema.yml
+++ b/config.schema.yml
@@ -16,6 +16,7 @@ properties:
     type: string
   transmission_metadata:
     type: string
+    default: ""
 
   min_cluster_size:
     type: integer

--- a/config.schema.yml
+++ b/config.schema.yml
@@ -81,31 +81,31 @@ properties:
     type: object
     properties:
       w_shape:
-        type: integer
+        type: number
         default: 10
       w_scale:
-        type: integer
+        type: number
         default: 0.1
       mcmcIterations:
         type: integer
         default: 1000
       startNeg:
-        type: integer
+        type: number
         default: 0.1
       startOff_r:
-        type: integer
+        type: number
         default: 1
       startOff_p:
-        type: integer
+        type: number
         default: 0.5
       startPi:
-        type: integer
+        type: number
         default: 0.5
       optiStart:
-        type: integer
+        type: number
         default: 2
       dateT:
-        type: integer
+        type: number
         default: 0
 
   fastbaps:
@@ -125,10 +125,10 @@ properties:
         minimum: 5
         maximum: 100
       knn:
-        type: number
+        type: integer
         minimum: 2
       maxIter:
-        type: number
+        type: integer
         minimum: 10000
         default: 100000
     required:

--- a/config.schema.yml
+++ b/config.schema.yml
@@ -50,32 +50,32 @@ properties:
       - mode
       - model
 
-gubbins:
-  type: object
-  properties:
-    prefix:
-      type: string
-    tree_builder:
-      type: string
-    min_snps:
-      type: integer
-      default: 3
-    min_window_size:
-      type: integer
-      default: 100
-    max_window_size:
-      type: integer
-      default: 10000
-    iterations:
-      type: integer
-      default: 10
-  required:
-    - prefix
-    - tree_builder
-    - min_snps
-    - min_window_size
-    - max_window_size
-    - iterations
+  gubbins:
+    type: object
+    properties:
+      prefix:
+        type: string
+      tree_builder:
+        type: string
+      min_snps:
+        type: integer
+        default: 3
+      min_window_size:
+        type: integer
+        default: 100
+      max_window_size:
+        type: integer
+        default: 10000
+      iterations:
+        type: integer
+        default: 10
+    required:
+      - prefix
+      - tree_builder
+      - min_snps
+      - min_window_size
+      - max_window_size
+      - iterations
 
   transphylo:
     type: object
@@ -111,13 +111,10 @@ gubbins:
   fastbaps:
     type: object
     properties:
-      script:
-        type: string
       levels:
         type: integer
         minimum: 1
     required:
-      - script
       - levels
 
   mandrake:

--- a/config.yml
+++ b/config.yml
@@ -15,6 +15,30 @@ ska:
   fastq_qual: 20
   fastq_cov: 4
 
+# IQ-TREE options
+iqtree:
+  enabled: true
+  mode: full
+  model: GTR+ASC+G
+
+# fastbaps options
+fastbaps:
+  # Number of hierarchical clustering levels
+  levels: 2
+
+# mandrake options
+mandrake:
+  knn: 50
+  perplexity: 25
+  maxIter: 100000
+
+# Microreact title, and your contact details
+microreact:
+  name: Listeria PopPIPE
+  website: https://www.poppunk.net
+  email: poppunk@poppunk.net
+  api_token: a1b2c3d4  ## see https://docs.microreact.org/api/access-tokens
+
 # gubbins options
 gubbins:
   prefix: gubbins
@@ -35,30 +59,3 @@ transphylo:
   startPi: 0.5
   optiStart: 2
   dateT: 0
-
-# IQ-TREE options
-iqtree:
-  enabled: true
-  mode: full
-  model: GTR+ASC+G
-
-# fastbaps options
-fastbaps:
-  # Number of hierarchical clustering levels
-  levels: 2
-  # Location of `run_fastbaps`.
-  # Find by running `system.file("run_fastbaps", package = "fastbaps")` in R.
-  script: run_fastbaps
-
-# mandrake options
-mandrake:
-  knn: 50
-  perplexity: 25
-  maxIter: 100000
-
-# Microreact title, and your contact details
-microreact:
-  name: Listeria PopPIPE
-  website: https://www.poppunk.net
-  email: poppunk@poppunk.net
-  api_token: a1b2c3d4  ## see https://docs.microreact.org/api/access-tokens

--- a/scripts/run_fastbaps.R
+++ b/scripts/run_fastbaps.R
@@ -1,0 +1,36 @@
+#!/usr/bin/env Rscript
+
+require(fastbaps)
+require(ape)
+
+# Load in arguments
+args <- commandArgs(trailingOnly = TRUE)
+aln_file <- args[1]
+output <- args[2]
+levels <- as.numeric(args[3])
+tree_file <- args[4]
+threads <- as.numeric(args[5])
+
+# load FASTA
+tryCatch(
+    expr = {
+        sparse_data <- fastbaps::import_fasta_sparse_nt(aln_file)
+        sparse_data <- fastbaps::optimise_prior(sparse_data, type = "baps")
+        tree <- ape::read.tree(tree_file)
+        multi <- fastbaps::multi_level_best_baps_partition(sparse_data,
+            h = tree, levels = levels, n.cores = threads)
+    },
+    error = function(e) {
+        print(e)
+        message("Problem loading fasta file – not generating subclusters")
+        snp_data <- fastbaps:::import_fasta_to_vector_each_nt()
+        names <-  gsub("^>", "", snp_data$seq.names)
+        null_clusters <- array(1, c(len(names), levels))
+        colnames(null_clusters) <- paste0("Level ", seq(1, levels))
+        multi <- cbind(data.frame(Isolates = snp_data$seq.names), null_clusters)
+    }
+)
+
+# write results
+write.table(multi, file = output, row.names = FALSE, col.names = TRUE,
+            sep = ",", quote = FALSE)

--- a/scripts/run_fastbaps.R
+++ b/scripts/run_fastbaps.R
@@ -23,7 +23,7 @@ tryCatch(
     error = function(e) {
         print(e)
         message("Problem loading fasta file – not generating subclusters")
-        snp_data <- fastbaps:::import_fasta_to_vector_each_nt()
+        snp_data <- fastbaps:::import_fasta_to_vector_each_nt(aln_file)
         names <-  gsub("^>", "", snp_data$seq.names)
         null_clusters <- array(1, c(len(names), levels))
         colnames(null_clusters) <- paste0("Level ", seq(1, levels))


### PR DESCRIPTION
Moves the fastbaps R script into the package. See https://github.com/gtonkinhill/fastbaps/blob/bb217dedf249a82e19483c63a8ad712f3fc13bcc/inst/run_fastbaps

If not enough variants are found, catch the error and instead create default clusters